### PR TITLE
Fix posts list markup

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -9,14 +9,16 @@ title: Home
 <div class="home">
   <ul class="post-list">
     {% for post in site.posts %}
+      <li>
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
-        
+
         <div class="post-content-preview">
           {{ post.content }}
         </div>
-        {%- unless forloop.last -%}
-          <hr class="post-divider">
-        {%- endunless -%}
+      </li>
+      {%- unless forloop.last -%}
+        <hr class="post-divider">
+      {%- endunless -%}
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
## Summary
- fix markup on index to wrap each post inside `<li>`

## Testing
- `bundle exec jekyll build` *(fails: rbenv: version `3.4.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846e500f854832283838bbfcee70f6a